### PR TITLE
Add support for CAA and TXT records

### DIFF
--- a/dnc
+++ b/dnc
@@ -72,7 +72,7 @@ def main():
     actions = []
 
     try:
-        options, args = getopt.getopt(sys.argv[1:], "46chmnstv")
+        options, args = getopt.getopt(sys.argv[1:], "462hmnstv")
     except getopt.GetoptError as err:
         print(err)
         sys.exit(1)

--- a/dnc
+++ b/dnc
@@ -33,10 +33,12 @@ def usage():
 
             	-4	Resolve and display A records (IPv4 addresses).
             	-6	Resolve and display AAAA records (IPv6 addresses).
+                -2  Resolve and display CAA records (RFC6844/Type 257)
             	-h	Display usage.
             	-m	Resolve and display MX records (Mail Exchange).
             	-n	Resolve and display NS records (Name Servers).
             	-s	Display SSL/TLS certificate expiration date.
+                -t  Resolve and display TXT records
             	-v	Display version."""
 
     print(textwrap.dedent(usage))
@@ -82,7 +84,7 @@ def main():
         if option == "-6":
             header.append("IPv6")
             actions.append((query, "AAAA"))
-        if option == "-c":
+        if option == "-2":
             header.append("CAA")
             actions.append((query, "CAA"))
         if option == "-h":

--- a/dnc
+++ b/dnc
@@ -70,7 +70,7 @@ def main():
     actions = []
 
     try:
-        options, args = getopt.getopt(sys.argv[1:], "46hmnsv")
+        options, args = getopt.getopt(sys.argv[1:], "46chmnsv")
     except getopt.GetoptError as err:
         print(err)
         sys.exit(1)
@@ -82,6 +82,9 @@ def main():
         if option == "-6":
             header.append("IPv6")
             actions.append((query, "AAAA"))
+        if option == "-c":
+            header.append("CAA")
+            actions.append((query, "CAA"))
         if option == "-h":
             usage()
             sys.exit(0)

--- a/dnc
+++ b/dnc
@@ -72,7 +72,7 @@ def main():
     actions = []
 
     try:
-        options, args = getopt.getopt(sys.argv[1:], "462hmnstv")
+        options, args = getopt.getopt(sys.argv[1:], "462chmnstv")
     except getopt.GetoptError as err:
         print(err)
         sys.exit(1)
@@ -87,6 +87,9 @@ def main():
         if option == "-2":
             header.append("CAA")
             actions.append((query, "CAA"))
+        if option == "-c":
+            header.append("CNAME")
+            actions.append((query, "CNAME"))
         if option == "-h":
             usage()
             sys.exit(0)

--- a/dnc
+++ b/dnc
@@ -70,7 +70,7 @@ def main():
     actions = []
 
     try:
-        options, args = getopt.getopt(sys.argv[1:], "46chmnsv")
+        options, args = getopt.getopt(sys.argv[1:], "46chmnstv")
     except getopt.GetoptError as err:
         print(err)
         sys.exit(1)
@@ -97,6 +97,9 @@ def main():
         if option == "-s":
             header.append("TLS")
             actions.append((tls, None))
+        if option == '-t':
+            header.append("TXT")
+            actions.append((query, "TXT"))
         if option == "-v":
             print("dnc 0.2.0")
             sys.exit(0)

--- a/dnc.1
+++ b/dnc.1
@@ -32,7 +32,7 @@
 .Nd Check domain names configuration
 .Sh SYNOPSIS
 .Nm
-.Op Fl 46hmnsv
+.Op Fl 46chmnstv
 .Ar domain
 .Sh DESCRIPTION
 .Nm
@@ -44,6 +44,8 @@ The options are as follows:
 Resolve and display A records (IPv4 addresses).
 .It Fl 6
 Resolve and display AAAA records (IPv6 addresses).
+.It Fl c
+Resolve and display CAA records (Certificate Authority Authorization)
 .It Fl h
 Display usage.
 .It Fl m
@@ -52,6 +54,8 @@ Resolve and display MX records (Mail Exchange).
 Resolve and display NS records (Name Servers).
 .It Fl s
 Display SSL/TLS certificate expiration date.
+.It Fl t
+Resolve and display TXT records (Generic text records)
 .It Fl v
 Display version.
 .El

--- a/dnc.1
+++ b/dnc.1
@@ -46,6 +46,8 @@ Resolve and display A records (IPv4 addresses).
 Resolve and display AAAA records (IPv6 addresses).
 .It Fl 2
 Resolve and display CAA records (Certificate Authority Authorization / RFC6844, Type 257)
+.It Fl c
+Resolve and display CNAME records
 .It Fl h
 Display usage.
 .It Fl m

--- a/dnc.1
+++ b/dnc.1
@@ -44,8 +44,8 @@ The options are as follows:
 Resolve and display A records (IPv4 addresses).
 .It Fl 6
 Resolve and display AAAA records (IPv6 addresses).
-.It Fl c
-Resolve and display CAA records (Certificate Authority Authorization)
+.It Fl 2
+Resolve and display CAA records (Certificate Authority Authorization / RFC6844, Type 257)
 .It Fl h
 Display usage.
 .It Fl m


### PR DESCRIPTION
Love the program--nice and simple! I added two command-line flags to look for CAA records (used to control SSL certificate issuance) and for generic TXT records (often used to do domain-level validation for SSL, SAML, etc.).